### PR TITLE
Add R_LARCH_JIRL_LO12

### DIFF
--- a/laelf.adoc
+++ b/laelf.adoc
@@ -704,6 +704,14 @@ with check 28-bit signed overflow and 4-bit aligned
 |R_LARCH_64_PCREL
 |64-bit PC relative
 |`+(*(uint64_t *) PC) = (S+A-PC) [63 ... 0]+`
+
+|110
+|R_LARCH_JIRL_LO12
+|Sign-extend [11 ... 2] bits of 32/64-bit absolute address to 16 bit
+|`+(*(uint32_t *) PC) [25 ... 10] = sign_ext((S+A) [11 ... 2])+`
+
+with checking for 4-bit alignment
+
 |===
 
 [bibliography]


### PR DESCRIPTION
Continuing the (unstarted) discussion at loongson/LoongArch-Documentation#69 where the repo itself is archived but ongoing discussion around it is still happening: e.g. at https://reviews.llvm.org/D138135 (have to justify the workarounds for `R_LARCH_PCALA_LO12`).